### PR TITLE
Add EarlyBind annotation to inject early user provided network interceptors

### DIFF
--- a/misk/src/main/kotlin/misk/web/actions/WebActionFactory.kt
+++ b/misk/src/main/kotlin/misk/web/actions/WebActionFactory.kt
@@ -21,6 +21,7 @@ import misk.web.Post
 import misk.web.Put
 import misk.web.RequestBody
 import misk.web.WebActionBinding
+import misk.web.interceptors.EarlyBind
 import misk.web.mediatype.MediaRange
 import misk.web.mediatype.MediaTypes
 import javax.inject.Inject
@@ -33,6 +34,7 @@ import kotlin.reflect.full.functions
 @Singleton
 internal class WebActionFactory @Inject constructor(
   private val injector: Injector,
+  @EarlyBind private val userProvidedEarlyNetworkInterceptorFactories: List<NetworkInterceptor.Factory>,
   private val userProvidedApplicationInterceptorFactories: List<ApplicationInterceptor.Factory>,
   private val userProvidedNetworkInterceptorFactories: List<NetworkInterceptor.Factory>,
   @MiskDefault private val miskNetworkInterceptorFactories: List<NetworkInterceptor.Factory>,
@@ -192,7 +194,8 @@ internal class WebActionFactory @Inject constructor(
   ): BoundAction<A> {
     // Ensure that default interceptors are called before any user provided interceptors
     val networkInterceptors =
-      miskNetworkInterceptorFactories.mapNotNull { it.create(action) } +
+      userProvidedEarlyNetworkInterceptorFactories.mapNotNull { it.create(action) } +
+        miskNetworkInterceptorFactories.mapNotNull { it.create(action) } +
         userProvidedNetworkInterceptorFactories.mapNotNull { it.create(action) }
 
     val applicationInterceptors =

--- a/misk/src/main/kotlin/misk/web/interceptors/EarlyBind.kt
+++ b/misk/src/main/kotlin/misk/web/interceptors/EarlyBind.kt
@@ -1,0 +1,20 @@
+package misk.web.interceptors
+
+import misk.MiskDefault
+import misk.web.NetworkInterceptor
+import javax.inject.Qualifier
+
+/**
+ * Denotes an early binding target, which will be automatically installed.
+ * For example, the [NetworkInterceptor] is bound with [EarlyBind] and is automatically
+ * installed before [MiskDefault] and non-annotated user provided interceptors.
+ */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+@Target(
+  AnnotationTarget.CLASS,
+  AnnotationTarget.VALUE_PARAMETER,
+  AnnotationTarget.FIELD,
+  AnnotationTarget.TYPE
+)
+annotation class EarlyBind


### PR DESCRIPTION
## Context
Developers need a way to provision network interceptors ahead of the misk defaults. 

## This PR
- Exposes a new annotation `@EarlyBind`
- Concatenates network interceptors with said annotation before interceptors annotated by MiskDefault
